### PR TITLE
Fix wrong unicode rendering

### DIFF
--- a/c2client/utils.py
+++ b/c2client/utils.py
@@ -6,4 +6,4 @@ def prettify_xml(string):
 
     parser = etree.XMLParser(remove_blank_text=True)
     tree = etree.fromstring(string, parser)
-    return etree.tostring(tree, pretty_print=True)
+    return etree.tostring(tree, pretty_print=True, encoding="unicode")


### PR DESCRIPTION
**Before patch:**
```console
╰─$ c2-ec2 CreateVirtualSwitch SwitchName это-не-ascii
<CreateVirtualSwitchResponse>
...
  <switch_name>&#1101;&#1090;&#1086;-&#1085;&#1077;-ascii</switch_name>
</CreateVirtualSwitchResponse>
```
**After patch:**
```console
╰─$ c2-ec2 CreateVirtualSwitch SwitchName это-не-ascii
<CreateVirtualSwitchResponse>
...
  <switch_name>это-не-ascii</switch_name>
</CreateVirtualSwitchResponse>
```

Signed-off-by: Pavel Kulyov <pkulev@croc.ru>