### PR TITLE
C2DEVEL-XXX: Allow json input

### DIFF
--- a/c2client/shell.py
+++ b/c2client/shell.py
@@ -168,6 +168,33 @@ def eks_main():
 
     print(json.dumps(result, indent=4, sort_keys=True))
 
+@exitcode
+def paas_main():
+    """Main function for PaaS API Client."""
+
+    action, args, verify = parse_arguments("c2-paas")
+
+    for key, value in args.items():
+        if value.isdigit():
+            args[key] = int(value)
+        elif value.lower() == "true":
+            args[key] = True
+        elif value.lower() == "false":
+            args[key] = False
+
+    paas_endpoint = get_env_var("PAAS_URL")
+
+    aws_access_key_id = get_env_var("AWS_ACCESS_KEY_ID")
+    aws_secret_access_key = get_env_var("AWS_SECRET_ACCESS_KEY")
+
+    paas_client = get_boto3_client("paas", paas_endpoint, aws_access_key_id, aws_secret_access_key, verify)
+
+    result = getattr(paas_client, inflection.underscore(action))(**from_dot_notation(args))
+
+    result.pop("ResponseMetadata", None)
+
+    print(json.dumps(result, indent=4, sort_keys=True))
+
 
 @exitcode
 def autoscaling_main():

--- a/c2client/shell.py
+++ b/c2client/shell.py
@@ -76,6 +76,11 @@ def parse_arguments(program):
         action="store_false",
         help="disable verifying ssl certificate",
         required=False)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Read parameters from json instead of key and value pairs.",
+        required=False)
     parser.add_argument("parameters", nargs="*",
         help="Any parameters for the action. "
              "Parameters specified by parameter key and "
@@ -83,10 +88,22 @@ def parse_arguments(program):
     args = parser.parse_args()
 
     params = args.parameters
+    if args.json:
+        parameters = read_json(params)
+    else:
+        parameters = dict(zip(params[::2], params[1::2]))
     no_verify_ssl = args.no_verify_ssl
-    parameters = dict(zip(params[::2], params[1::2]))
 
     return args.action, parameters, no_verify_ssl
+
+
+def read_json(params):
+    if params:
+        json_str = params[0]
+        if json_str == "-":
+            json_str = sys.stdin.read()
+        return json.loads(json_str)
+    return {}
 
 
 @exitcode

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "c2-cw = c2client.shell:cw_main",
             "c2-ec2 = c2client.shell:ec2_main",
             "c2-eks = c2client.shell:eks_main",
+            "c2-paas = c2client.shell:paas_main",
             "c2-as = c2client.shell:autoscaling_main",
             "c2rc-convert = c2client.c2rc_convert:main",
         ]


### PR DESCRIPTION
Allow put Json into input. Adds `--json` argument to allow this feature.
Examples:
1. Json as argument:
`c2-paas DescribeService '{"serviceId":"fm-cluster-7867D61F"}' --no-verify-ssl --json`
2. Json as stdin:
`echo '{"serviceId":"fm-cluster-7867D61F"}' | c2-paas DescribeService - --no-verify-ssl --json`

Based on #17 