### PR TITLE
C2DEVEL-13870: Add getting error_code BotoServerError

### DIFF
--- a/c2client/clients.py
+++ b/c2client/clients.py
@@ -33,7 +33,8 @@ def exitcode(func: callable):
         try:
             func(*args, **kwargs)
         except boto.exception.BotoServerError as error:
-            return f"{error.error_code}: {error.message}"
+            error_code = error.error_code or error.body.get("__type")
+            return f"{error_code}: {error.message}"
         except Exception as e:
             return e
     return wrapper


### PR DESCRIPTION
Add getting error_code of BotoServerError by key "__type" from error.body, because InvalidTimeRangeException wasn't shown, when except

https://jira.croc.ru/browse/C2DEVEL-13870